### PR TITLE
enforcing the minion to load the oldstyle defaults only if yadt.services...

### DIFF
--- a/src/main/python/yadtminion/configuration.py
+++ b/src/main/python/yadtminion/configuration.py
@@ -4,7 +4,7 @@ import os
 
 
 def load_yadt_defaults():
-    if os.path.exists('/etc/yadt.services'):
+    if os.path.isfile('/etc/yadt.services'):
         return load_yadt_defaults_oldstyle()
     else:
         return load_yadt_defaults_newstyle()


### PR DESCRIPTION
if you're changing the YADT_LOG_DIR in 00_defaults.yaml the yadt-minion is still using the old log dir because its using the defaults_oldstyle.

this "patch" fixes this issue

@esc @mriehl @arnehilmann please review
