### PR TITLE
fixing some flake8 errors

### DIFF
--- a/src/main/python/yadtminion/configuration.py
+++ b/src/main/python/yadtminion/configuration.py
@@ -1,11 +1,12 @@
 import yadtminion
-from yadtminion import Status
 import os
+import sys
 
 
 def load_yadt_defaults():
     if os.path.isfile('/etc/yadt.services'):
-        sys.stderr.write("/etc/yadt.services is unsupported, please migrate to /etc/yadt.conf.d : https://github.com/yadt/yadtshell/wiki/Host-Configuration\n")
+        sys.stderr.write(
+            "/etc/yadt.services is unsupported, please migrate to /etc/yadt.conf.d : https://github.com/yadt/yadtshell/wiki/Host-Configuration\n")
         sys.exit(1)
     else:
         return load_yadt_defaults_newstyle()


### PR DESCRIPTION
fixing some pep8 errors:

``` bash
[WARN]  flake8: src/main/python/yadtminion/configuration.py:2:1: F401 'Status' imported but unused
[WARN]  flake8: src/main/python/yadtminion/configuration.py:8:9: F821 undefined name 'sys')
[WARN]  flake8: src/main/python/yadtminion/configuration.py:9:9: F821 undefined name 'sys'
```
