### PR TITLE
Add basic Upstart support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [bdist_rpm]
 packager = Arne Hilmann <arne.hilmann@gmail.com>
-requires = python >= 2.4 PyYAML yum python-netifaces python-simplejson
+requires = python >= 2.6 PyYAML yum python-netifaces python-simplejson
 release = 0%{?dist}

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -285,15 +285,19 @@ class Status(object):
                                               'service_defs',
                                               'artefacts_filter']]
 
+    def get_service_init_details(self, service):
+        init_script = '/etc/init.d/%s' % service['name']
+        service_artefact = self.yumdeps.get_service_artefact(init_script)
+        if os.path.exists(init_script):
+            service['init_script'] = init_script
+        else:
+            service['state_handling'] = 'serverside'
+        return service_artefact
+
     def setup_services(self):
         for name, service in self.services.iteritems():
-            init_script = '/etc/init.d/%s' % name
-            service_artefact = self.yumdeps.get_service_artefact(init_script)
             service['name'] = name
-            if os.path.exists(init_script):
-                service['init_script'] = init_script
-            else:
-                service['state_handling'] = 'serverside'
+            service_artefact = self.get_service_init_details(service)
             if service_artefact:
                 service['service_artefact'] = service_artefact
                 toplevel_artefacts = self.yumdeps.get_all_whatrequires(

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -227,25 +227,7 @@ class Status(object):
 
         self.load_defaults_and_settings(only_config=False)
 
-        for name, service in self.services.iteritems():
-            init_script = '/etc/init.d/%s' % name
-            service_artefact = self.yumdeps.get_service_artefact(init_script)
-            service['name'] = name
-            if os.path.exists(init_script):
-                service['init_script'] = init_script
-            else:
-                service['state_handling'] = 'serverside'
-            if service_artefact:
-                service['service_artefact'] = service_artefact
-                toplevel_artefacts = self.yumdeps.get_all_whatrequires(
-                    service_artefact)
-                service['toplevel_artefacts'] = toplevel_artefacts
-                service.setdefault('needs_artefacts', []).extend(
-                    map(self.yumdeps.strip_version, filter(
-                        self.artefacts_filter, self.yumdeps.get_all_requires([service_artefact]))))
-                service['needs_artefacts'].extend(map(self.yumdeps.strip_version, filter(
-                    self.artefacts_filter, toplevel_artefacts)))
-
+        self.setup_services()
         self.add_services_ignore()
         self.add_services_states()
         self.add_services_extra()
@@ -302,6 +284,26 @@ class Status(object):
                                               'yumdeps',
                                               'service_defs',
                                               'artefacts_filter']]
+
+    def setup_services(self):
+        for name, service in self.services.iteritems():
+            init_script = '/etc/init.d/%s' % name
+            service_artefact = self.yumdeps.get_service_artefact(init_script)
+            service['name'] = name
+            if os.path.exists(init_script):
+                service['init_script'] = init_script
+            else:
+                service['state_handling'] = 'serverside'
+            if service_artefact:
+                service['service_artefact'] = service_artefact
+                toplevel_artefacts = self.yumdeps.get_all_whatrequires(
+                    service_artefact)
+                service['toplevel_artefacts'] = toplevel_artefacts
+                service.setdefault('needs_artefacts', []).extend(
+                    map(self.yumdeps.strip_version, filter(
+                        self.artefacts_filter, self.yumdeps.get_all_requires([service_artefact]))))
+                service['needs_artefacts'].extend(map(self.yumdeps.strip_version, filter(
+                    self.artefacts_filter, toplevel_artefacts)))
 
     def add_services_states(self):
         for service in self.services.values():

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -312,7 +312,7 @@ class Status(object):
         return init_script, init_type
 
     def get_service_init_details(self, service):
-        init_script, init_type = self.get_init_type(service['name'])
+        init_script, init_type = self.get_init_script_and_type(service['name'])
         if init_script:
             service_artefact = self.yumdeps.get_service_artefact(init_script)
             service['init_script'] = init_script

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -177,16 +177,11 @@ class Status(object):
         self._determine_stop_artefacts()
 
     def determine_latest_kernel(self):
+        kernels = [a.replace('/', '-').replace('kernel-uek', 'kernel')
+                   for a in self.current_artefacts
+                   if a.startswith(('kernel/', 'kernel-uek/'))]
         kernel_artefacts = sorted(
-            map(
-                stringToVersion,
-                [a.replace('/', '-').replace('kernel-uek', 'kernel')
-                 for a in self.current_artefacts
-                    if (
-                        a.startswith('kernel/')
-                        or a.startswith('kernel-uek/'))
-                 ]
-            ),
+            map(stringToVersion, kernels),
             cmp=rpm.labelCompare, reverse=True)
 
         if kernel_artefacts:

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -400,7 +400,8 @@ class Status(object):
 
     def host_is_up_to_date(self):
         status = self.get_status()
-        return False if status['next_artefacts'] else True
+        pending_updates = status['next_artefacts']
+        return not pending_updates
 
     def get_status(self):
         return dict(filter(lambda item: item[0] in self.structure_keys, self.__dict__.iteritems()))

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -241,11 +241,7 @@ class Status(object):
         self.yumdeps.load_all_updates()
         for a in filter(self.artefacts_filter, self.yumdeps.all_updates.keys()):
             self.updates[a] = self.yumdeps.all_updates[a]
-
-        if len(self.updates):
-            self.state = 'update_needed'
-        else:
-            self.state = 'uptodate'
+        self.state = 'update_needed' if self.updates else 'uptodate'
 
         self.lockstate = self.get_lock_state()
 

--- a/src/main/scripts/yadt-service-init-type
+++ b/src/main/scripts/yadt-service-init-type
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+import sys
+
+from yadtminion import Status
+
+_, init_type = Status.get_init_script_and_type(sys.argv[1])
+print "YADT_INIT_TYPE='{0}'".format(init_type)

--- a/src/main/scripts/yadt-service-start
+++ b/src/main/scripts/yadt-service-start
@@ -19,7 +19,9 @@ if ! is_already_starting; then
         if [[ $YADT_INIT_TYPE == "sysv" ]]; then
             sudo service $SERVICE start
         elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
-            sudo initctl start $SERVICE
+            if sudo initctl status $SERVICE | grep -q "stop/waiting"; then
+                sudo initctl start $SERVICE
+            fi
         fi
     fi
     exit

--- a/src/main/scripts/yadt-service-start
+++ b/src/main/scripts/yadt-service-start
@@ -4,11 +4,12 @@ set -e -E -C -u -o pipefail
 export SERVICE=${1:?no SERVICE specified}
 . yadt-service-checkaccess
 
-is_already_running() {
+is_already_starting() {
+    # Only for SysV init, in case someone has broken init scripts.
     pgrep -f "(service $SERVICE start|.*sh /etc/rc..d/S..$SERVICE start)" > /dev/null
 }
 
-if ! is_already_running; then
+if ! is_already_starting; then
     echo "starting $SERVICE"
     if [[ $RELEASEVER == "7"* ]]
     then
@@ -19,7 +20,7 @@ if ! is_already_running; then
     exit
 fi
 
-while is_already_running; do
+while is_already_starting; do
     echo "service $SERVICE is starting already, checking again in 2 seconds" >&2
     sleep 2
 done

--- a/src/main/scripts/yadt-service-start
+++ b/src/main/scripts/yadt-service-start
@@ -15,11 +15,11 @@ if ! is_already_starting; then
     then
         sudo systemctl start $SERVICE
     else
-        eval $(yadt-service-init-type $YADT_SERVICE)
+        eval $(yadt-service-init-type $SERVICE)
         if [[ $YADT_INIT_TYPE == "sysv" ]]; then
-            sudo service $YADT_SERVICE start
+            sudo service $SERVICE start
         elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
-            sudo initctl start $YADT_SERVICE
+            sudo initctl start $SERVICE
         fi
     fi
     exit

--- a/src/main/scripts/yadt-service-start
+++ b/src/main/scripts/yadt-service-start
@@ -15,7 +15,12 @@ if ! is_already_starting; then
     then
         sudo systemctl start $SERVICE
     else
-        sudo service $SERVICE start
+        eval $(yadt-service-init-type $YADT_SERVICE)
+        if [[ $YADT_INIT_TYPE == "sysv" ]]; then
+            sudo service $YADT_SERVICE start
+        elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
+            sudo initctl start $YADT_SERVICE
+        fi
     fi
     exit
 fi

--- a/src/main/scripts/yadt-service-status
+++ b/src/main/scripts/yadt-service-status
@@ -6,5 +6,10 @@ export YADT_SERVICE=${1:?no YADT_SERVICE specified}
 if [[ $RELEASEVER == "7"* ]]; then
     sudo systemctl status $YADT_SERVICE
 else
-    sudo service $YADT_SERVICE status
+    eval $(yadt-service-init-type $YADT_SERVICE)
+    if [[ $YADT_INIT_TYPE == "sysv" ]]; then
+        sudo service $YADT_SERVICE status
+    elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
+        sudo initctl status $YADT_SERVICE
+    fi
 fi

--- a/src/main/scripts/yadt-service-status
+++ b/src/main/scripts/yadt-service-status
@@ -10,6 +10,8 @@ else
     if [[ $YADT_INIT_TYPE == "sysv" ]]; then
         sudo service $SERVICE status
     elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
-        sudo initctl status $SERVICE
+        if sudo initctl status $SERVICE | grep -q "stop/waiting"; then
+            exit 3
+        fi
     fi
 fi

--- a/src/main/scripts/yadt-service-status
+++ b/src/main/scripts/yadt-service-status
@@ -1,15 +1,15 @@
 #!/bin/bash
 set -e -E -C -u -o pipefail
 
-export YADT_SERVICE=${1:?no YADT_SERVICE specified}
+export SERVICE=${1:?no YADT_SERVICE specified}
 
 if [[ $RELEASEVER == "7"* ]]; then
-    sudo systemctl status $YADT_SERVICE
+    sudo systemctl status $SERVICE
 else
-    eval $(yadt-service-init-type $YADT_SERVICE)
+    eval $(yadt-service-init-type $SERVICE)
     if [[ $YADT_INIT_TYPE == "sysv" ]]; then
-        sudo service $YADT_SERVICE status
+        sudo service $SERVICE status
     elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
-        sudo initctl status $YADT_SERVICE
+        sudo initctl status $SERVICE
     fi
 fi

--- a/src/main/scripts/yadt-service-stop
+++ b/src/main/scripts/yadt-service-stop
@@ -11,6 +11,8 @@ else
     if [[ $YADT_INIT_TYPE == "sysv" ]]; then
         sudo service $SERVICE stop
     elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
-        sudo initctl stop $SERVICE
+        if sudo initctl status $SERVICE | grep -qv "stop/waiting"; then
+            sudo initctl stop $SERVICE
+        fi
     fi
 fi

--- a/src/main/scripts/yadt-service-stop
+++ b/src/main/scripts/yadt-service-stop
@@ -7,5 +7,10 @@ export SERVICE=${1:?no SERVICE specified}
 if [[ $RELEASEVER == "7"* ]]; then
     sudo systemctl stop $SERVICE
 else
-    sudo service $SERVICE stop
+    eval $(yadt-service-init-type $YADT_SERVICE)
+    if [[ $YADT_INIT_TYPE == "sysv" ]]; then
+        sudo service $YADT_SERVICE stop
+    elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
+        sudo initctl stop $YADT_SERVICE
+    fi
 fi

--- a/src/main/scripts/yadt-service-stop
+++ b/src/main/scripts/yadt-service-stop
@@ -7,10 +7,10 @@ export SERVICE=${1:?no SERVICE specified}
 if [[ $RELEASEVER == "7"* ]]; then
     sudo systemctl stop $SERVICE
 else
-    eval $(yadt-service-init-type $YADT_SERVICE)
+    eval $(yadt-service-init-type $SERVICE)
     if [[ $YADT_INIT_TYPE == "sysv" ]]; then
-        sudo service $YADT_SERVICE stop
+        sudo service $SERVICE stop
     elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
-        sudo initctl stop $YADT_SERVICE
+        sudo initctl stop $SERVICE
     fi
 fi


### PR DESCRIPTION
The changes add some support for Upstart, with the restriction that /etc/init/*.override files are not yet taken into account. Which init system to use is decided by the get_init_script_and_type() method.