### PR TITLE
Add support for Upstart overrides

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [bdist_rpm]
 packager = Arne Hilmann <arne.hilmann@gmail.com>
-requires = python >= 2.4 PyYAML yum python-netifaces python-simplejson
+requires = python >= 2.6 PyYAML yum python-netifaces python-simplejson
 release = 0%{?dist}

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -285,15 +285,19 @@ class Status(object):
                                               'service_defs',
                                               'artefacts_filter']]
 
+    def get_service_init_details(self, service):
+        init_script = '/etc/init.d/%s' % service['name']
+        service_artefact = self.yumdeps.get_service_artefact(init_script)
+        if os.path.exists(init_script):
+            service['init_script'] = init_script
+        else:
+            service['state_handling'] = 'serverside'
+        return service_artefact
+
     def setup_services(self):
         for name, service in self.services.iteritems():
-            init_script = '/etc/init.d/%s' % name
-            service_artefact = self.yumdeps.get_service_artefact(init_script)
             service['name'] = name
-            if os.path.exists(init_script):
-                service['init_script'] = init_script
-            else:
-                service['state_handling'] = 'serverside'
+            service_artefact = self.get_service_init_details(service)
             if service_artefact:
                 service['service_artefact'] = service_artefact
                 toplevel_artefacts = self.yumdeps.get_all_whatrequires(

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -227,25 +227,7 @@ class Status(object):
 
         self.load_defaults_and_settings(only_config=False)
 
-        for name, service in self.services.iteritems():
-            init_script = '/etc/init.d/%s' % name
-            service_artefact = self.yumdeps.get_service_artefact(init_script)
-            service['name'] = name
-            if os.path.exists(init_script):
-                service['init_script'] = init_script
-            else:
-                service['state_handling'] = 'serverside'
-            if service_artefact:
-                service['service_artefact'] = service_artefact
-                toplevel_artefacts = self.yumdeps.get_all_whatrequires(
-                    service_artefact)
-                service['toplevel_artefacts'] = toplevel_artefacts
-                service.setdefault('needs_artefacts', []).extend(
-                    map(self.yumdeps.strip_version, filter(
-                        self.artefacts_filter, self.yumdeps.get_all_requires([service_artefact]))))
-                service['needs_artefacts'].extend(map(self.yumdeps.strip_version, filter(
-                    self.artefacts_filter, toplevel_artefacts)))
-
+        self.setup_services()
         self.add_services_ignore()
         self.add_services_states()
         self.add_services_extra()
@@ -302,6 +284,26 @@ class Status(object):
                                               'yumdeps',
                                               'service_defs',
                                               'artefacts_filter']]
+
+    def setup_services(self):
+        for name, service in self.services.iteritems():
+            init_script = '/etc/init.d/%s' % name
+            service_artefact = self.yumdeps.get_service_artefact(init_script)
+            service['name'] = name
+            if os.path.exists(init_script):
+                service['init_script'] = init_script
+            else:
+                service['state_handling'] = 'serverside'
+            if service_artefact:
+                service['service_artefact'] = service_artefact
+                toplevel_artefacts = self.yumdeps.get_all_whatrequires(
+                    service_artefact)
+                service['toplevel_artefacts'] = toplevel_artefacts
+                service.setdefault('needs_artefacts', []).extend(
+                    map(self.yumdeps.strip_version, filter(
+                        self.artefacts_filter, self.yumdeps.get_all_requires([service_artefact]))))
+                service['needs_artefacts'].extend(map(self.yumdeps.strip_version, filter(
+                    self.artefacts_filter, toplevel_artefacts)))
 
     def add_services_states(self):
         for service in self.services.values():

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -312,7 +312,7 @@ class Status(object):
         return init_script, init_type
 
     def get_service_init_details(self, service):
-        init_script, init_type = self.get_init_type(service['name'])
+        init_script, init_type = self.get_init_script_and_type(service['name'])
         if init_script:
             service_artefact = self.yumdeps.get_service_artefact(init_script)
             service['init_script'] = init_script

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -320,8 +320,8 @@ class Status(object):
         init_scripts, init_type = self.get_init_scripts_and_type(service['name'])
         if init_scripts:
             service_artefacts = [
-                        self.yumdeps.get_service_artefact(init_script)
-                        for init_script in init_scripts]
+                self.yumdeps.get_service_artefact(init_script)
+                for init_script in init_scripts]
             # Unpackaged files give None as service_artefact, filter those out.
             service_artefacts = filter(bool, service_artefacts)
 

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -177,16 +177,11 @@ class Status(object):
         self._determine_stop_artefacts()
 
     def determine_latest_kernel(self):
+        kernels = [a.replace('/', '-').replace('kernel-uek', 'kernel')
+                   for a in self.current_artefacts
+                   if a.startswith(('kernel/', 'kernel-uek/'))]
         kernel_artefacts = sorted(
-            map(
-                stringToVersion,
-                [a.replace('/', '-').replace('kernel-uek', 'kernel')
-                 for a in self.current_artefacts
-                    if (
-                        a.startswith('kernel/')
-                        or a.startswith('kernel-uek/'))
-                 ]
-            ),
+            map(stringToVersion, kernels),
             cmp=rpm.labelCompare, reverse=True)
 
         if kernel_artefacts:

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -400,7 +400,8 @@ class Status(object):
 
     def host_is_up_to_date(self):
         status = self.get_status()
-        return False if status['next_artefacts'] else True
+        pending_updates = status['next_artefacts']
+        return not pending_updates
 
     def get_status(self):
         return dict(filter(lambda item: item[0] in self.structure_keys, self.__dict__.iteritems()))

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -277,15 +277,17 @@ class Status(object):
                                               'artefacts_filter']]
 
     @staticmethod
-    def get_init_script_and_type(service_name):
+    def get_init_scripts_and_type(service_name):
         sysv_init_script = '/etc/init.d/%s' % service_name
         upstart_init_script = '/etc/init/%s.conf' % service_name
+        upstart_override = '/etc/init/%s.override' % service_name
         try:
             chkconfig_result = subprocess.call(['chkconfig', service_name]) == 0
         except Exception:
             chkconfig_result = None
         sysv_exists = os.path.exists(sysv_init_script)
         upstart_exists = os.path.exists(upstart_init_script)
+        override_exists = os.path.exists(upstart_override)
 
         if chkconfig_result:
             init_type = "sysv"
@@ -303,38 +305,51 @@ class Status(object):
                 init_type = "serverside"
 
         if init_type == "sysv":
-            init_script = sysv_init_script
+            init_scripts = (sysv_init_script,)
         elif init_type == "upstart":
-            init_script = upstart_init_script
+            if override_exists:
+                init_scripts = (upstart_init_script, upstart_override)
+            else:
+                init_scripts = (upstart_init_script,)
         else:
-            init_script = ""
+            init_scripts = tuple()
 
-        return init_script, init_type
+        return init_scripts, init_type
 
     def get_service_init_details(self, service):
-        init_script, init_type = self.get_init_script_and_type(service['name'])
-        if init_script:
-            service_artefact = self.yumdeps.get_service_artefact(init_script)
-            service['init_script'] = init_script
+        init_scripts, init_type = self.get_init_scripts_and_type(service['name'])
+        if init_scripts:
+            service_artefacts = [
+                        self.yumdeps.get_service_artefact(init_script)
+                        for init_script in init_scripts]
+            # Unpackaged files give None as service_artefact, filter those out.
+            service_artefacts = filter(bool, service_artefacts)
+
+            service['init_script'] = init_scripts
             service['init_type'] = init_type
         else:
             service['state_handling'] = init_type
-            service_artefact = None
+            service_artefacts = []
 
-        return service_artefact
+        return service_artefacts
 
     def setup_services(self):
         for name, service in self.services.iteritems():
             service['name'] = name
-            service_artefact = self.get_service_init_details(service)
-            if service_artefact:
-                service['service_artefact'] = service_artefact
-                toplevel_artefacts = self.yumdeps.get_all_whatrequires(
-                    service_artefact)
-                service['toplevel_artefacts'] = toplevel_artefacts
-                service.setdefault('needs_artefacts', []).extend(
-                    map(self.yumdeps.strip_version, filter(
-                        self.artefacts_filter, self.yumdeps.get_all_requires([service_artefact]))))
+            service_artefacts = self.get_service_init_details(service)
+            print "artefacts for service {0}: {1}".format(service, service_artefacts)
+            if service_artefacts:
+                service['service_artefact'] = service_artefacts
+                service.setdefault('needs_artefacts', [])
+                toplevel_artefacts = set()
+                for artefact in service_artefacts:
+                    toplevel_artefacts.update(self.yumdeps.get_all_whatrequires(artefact))
+                    print "handling artefact", artefact
+                    service['needs_artefacts'].extend(
+                        map(self.yumdeps.strip_version, filter(
+                            self.artefacts_filter, self.yumdeps.get_all_requires(artefact))))
+                service['toplevel_artefacts'] = list(toplevel_artefacts)
+
                 service['needs_artefacts'].extend(map(self.yumdeps.strip_version, filter(
                     self.artefacts_filter, toplevel_artefacts)))
 

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -281,24 +281,28 @@ class Status(object):
         sysv_init_script = '/etc/init.d/%s' % service_name
         upstart_init_script = '/etc/init/%s.conf' % service_name
         upstart_override = '/etc/init/%s.override' % service_name
-        try:
-            chkconfig_result = subprocess.call(['chkconfig', service_name]) == 0
-        except Exception:
-            chkconfig_result = None
         sysv_exists = os.path.exists(sysv_init_script)
         upstart_exists = os.path.exists(upstart_init_script)
         override_exists = os.path.exists(upstart_override)
 
-        if chkconfig_result:
+        try:
+            chkconfig_result = subprocess.call(['chkconfig', service_name]) == 0
+        except Exception:
+            chkconfig_result = None
+        chkconfig_success = True
+        chkconfig_failed = False
+        chkconfig_does_not_exist = None
+
+        if chkconfig_result == chkconfig_success:
             init_type = "sysv"
-        elif chkconfig_result is None:
+        elif chkconfig_result is chkconfig_does_not_exist:
             if upstart_exists:
                 init_type = "upstart"
             elif sysv_exists:
                 init_type = "sysv"
             else:
                 init_type = "serverside"
-        elif chkconfig_result == False:
+        elif chkconfig_result == chkconfig_failed:
             if upstart_exists:
                 init_type = "upstart"
             else:

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -298,7 +298,7 @@ class Status(object):
                 init_type = "sysv"
             else:
                 init_type = "serverside"
-        else:
+        elif chkconfig_result == False:
             if upstart_exists:
                 init_type = "upstart"
             else:

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -241,11 +241,7 @@ class Status(object):
         self.yumdeps.load_all_updates()
         for a in filter(self.artefacts_filter, self.yumdeps.all_updates.keys()):
             self.updates[a] = self.yumdeps.all_updates[a]
-
-        if len(self.updates):
-            self.state = 'update_needed'
-        else:
-            self.state = 'uptodate'
+        self.state = 'update_needed' if self.updates else 'uptodate'
 
         self.lockstate = self.get_lock_state()
 

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -337,14 +337,12 @@ class Status(object):
         for name, service in self.services.iteritems():
             service['name'] = name
             service_artefacts = self.get_service_init_details(service)
-            print "artefacts for service {0}: {1}".format(service, service_artefacts)
             if service_artefacts:
                 service['service_artefact'] = service_artefacts
                 service.setdefault('needs_artefacts', [])
                 toplevel_artefacts = set()
                 for artefact in service_artefacts:
                     toplevel_artefacts.update(self.yumdeps.get_all_whatrequires(artefact))
-                    print "handling artefact", artefact
                     service['needs_artefacts'].extend(
                         map(self.yumdeps.strip_version, filter(
                             self.artefacts_filter, self.yumdeps.get_all_requires(artefact))))

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -345,7 +345,7 @@ class Status(object):
                     toplevel_artefacts.update(self.yumdeps.get_all_whatrequires(artefact))
                     service['needs_artefacts'].extend(
                         map(self.yumdeps.strip_version, filter(
-                            self.artefacts_filter, self.yumdeps.get_all_requires(artefact))))
+                            self.artefacts_filter, self.yumdeps.get_all_requires([artefact]))))
                 service['toplevel_artefacts'] = list(toplevel_artefacts)
 
                 service['needs_artefacts'].extend(map(self.yumdeps.strip_version, filter(

--- a/src/main/scripts/yadt-service-init-type
+++ b/src/main/scripts/yadt-service-init-type
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+import sys
+
+from yadtminion import Status
+
+_, init_type = Status.get_init_script_and_type(sys.argv[1])
+print "YADT_INIT_TYPE='{0}'".format(init_type)

--- a/src/main/scripts/yadt-service-init-type
+++ b/src/main/scripts/yadt-service-init-type
@@ -3,5 +3,5 @@ import sys
 
 from yadtminion import Status
 
-_, init_type = Status.get_init_script_and_type(sys.argv[1])
+_, init_type = Status.get_init_scripts_and_type(sys.argv[1])
 print "YADT_INIT_TYPE='{0}'".format(init_type)

--- a/src/main/scripts/yadt-service-start
+++ b/src/main/scripts/yadt-service-start
@@ -19,7 +19,9 @@ if ! is_already_starting; then
         if [[ $YADT_INIT_TYPE == "sysv" ]]; then
             sudo service $SERVICE start
         elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
-            sudo initctl start $SERVICE
+            if sudo initctl status $SERVICE | grep -q "stop/waiting"; then
+                sudo initctl start $SERVICE
+            fi
         fi
     fi
     exit

--- a/src/main/scripts/yadt-service-start
+++ b/src/main/scripts/yadt-service-start
@@ -4,9 +4,14 @@ set -e -E -C -u -o pipefail
 export SERVICE=${1:?no SERVICE specified}
 . yadt-service-checkaccess
 
+eval $(yadt-service-init-type $SERVICE)
+
 is_already_starting() {
-    # Only for SysV init, in case someone has broken init scripts.
-    pgrep -f "(service $SERVICE start|.*sh /etc/rc..d/S..$SERVICE start)" > /dev/null
+    if [[ $YADT_INIT_TYPE == "sysv" ]]; then
+        pgrep -f "(service $SERVICE start|.*sh /etc/rc..d/S..$SERVICE start)" > /dev/null
+    elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
+        sudo initctl status $SERVICE | grep "start/" | grep -qv "start/running"
+    fi
 }
 
 if ! is_already_starting; then
@@ -15,7 +20,6 @@ if ! is_already_starting; then
     then
         sudo systemctl start $SERVICE
     else
-        eval $(yadt-service-init-type $SERVICE)
         if [[ $YADT_INIT_TYPE == "sysv" ]]; then
             sudo service $SERVICE start
         elif [[ $YADT_INIT_TYPE == "upstart" ]]; then

--- a/src/main/scripts/yadt-service-start
+++ b/src/main/scripts/yadt-service-start
@@ -4,11 +4,12 @@ set -e -E -C -u -o pipefail
 export SERVICE=${1:?no SERVICE specified}
 . yadt-service-checkaccess
 
-is_already_running() {
+is_already_starting() {
+    # Only for SysV init, in case someone has broken init scripts.
     pgrep -f "(service $SERVICE start|.*sh /etc/rc..d/S..$SERVICE start)" > /dev/null
 }
 
-if ! is_already_running; then
+if ! is_already_starting; then
     echo "starting $SERVICE"
     if [[ $RELEASEVER == "7"* ]]
     then
@@ -19,7 +20,7 @@ if ! is_already_running; then
     exit
 fi
 
-while is_already_running; do
+while is_already_starting; do
     echo "service $SERVICE is starting already, checking again in 2 seconds" >&2
     sleep 2
 done

--- a/src/main/scripts/yadt-service-start
+++ b/src/main/scripts/yadt-service-start
@@ -15,11 +15,11 @@ if ! is_already_starting; then
     then
         sudo systemctl start $SERVICE
     else
-        eval $(yadt-service-init-type $YADT_SERVICE)
+        eval $(yadt-service-init-type $SERVICE)
         if [[ $YADT_INIT_TYPE == "sysv" ]]; then
-            sudo service $YADT_SERVICE start
+            sudo service $SERVICE start
         elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
-            sudo initctl start $YADT_SERVICE
+            sudo initctl start $SERVICE
         fi
     fi
     exit

--- a/src/main/scripts/yadt-service-start
+++ b/src/main/scripts/yadt-service-start
@@ -15,7 +15,12 @@ if ! is_already_starting; then
     then
         sudo systemctl start $SERVICE
     else
-        sudo service $SERVICE start
+        eval $(yadt-service-init-type $YADT_SERVICE)
+        if [[ $YADT_INIT_TYPE == "sysv" ]]; then
+            sudo service $YADT_SERVICE start
+        elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
+            sudo initctl start $YADT_SERVICE
+        fi
     fi
     exit
 fi

--- a/src/main/scripts/yadt-service-status
+++ b/src/main/scripts/yadt-service-status
@@ -6,5 +6,10 @@ export YADT_SERVICE=${1:?no YADT_SERVICE specified}
 if [[ $RELEASEVER == "7"* ]]; then
     sudo systemctl status $YADT_SERVICE
 else
-    sudo service $YADT_SERVICE status
+    eval $(yadt-service-init-type $YADT_SERVICE)
+    if [[ $YADT_INIT_TYPE == "sysv" ]]; then
+        sudo service $YADT_SERVICE status
+    elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
+        sudo initctl status $YADT_SERVICE
+    fi
 fi

--- a/src/main/scripts/yadt-service-status
+++ b/src/main/scripts/yadt-service-status
@@ -10,6 +10,8 @@ else
     if [[ $YADT_INIT_TYPE == "sysv" ]]; then
         sudo service $SERVICE status
     elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
-        sudo initctl status $SERVICE
+        if sudo initctl status $SERVICE | grep -q "stop/waiting"; then
+            exit 3
+        fi
     fi
 fi

--- a/src/main/scripts/yadt-service-status
+++ b/src/main/scripts/yadt-service-status
@@ -1,15 +1,15 @@
 #!/bin/bash
 set -e -E -C -u -o pipefail
 
-export YADT_SERVICE=${1:?no YADT_SERVICE specified}
+export SERVICE=${1:?no YADT_SERVICE specified}
 
 if [[ $RELEASEVER == "7"* ]]; then
-    sudo systemctl status $YADT_SERVICE
+    sudo systemctl status $SERVICE
 else
-    eval $(yadt-service-init-type $YADT_SERVICE)
+    eval $(yadt-service-init-type $SERVICE)
     if [[ $YADT_INIT_TYPE == "sysv" ]]; then
-        sudo service $YADT_SERVICE status
+        sudo service $SERVICE status
     elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
-        sudo initctl status $YADT_SERVICE
+        sudo initctl status $SERVICE
     fi
 fi

--- a/src/main/scripts/yadt-service-stop
+++ b/src/main/scripts/yadt-service-stop
@@ -11,6 +11,8 @@ else
     if [[ $YADT_INIT_TYPE == "sysv" ]]; then
         sudo service $SERVICE stop
     elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
-        sudo initctl stop $SERVICE
+        if sudo initctl status $SERVICE | grep -qv "stop/waiting"; then
+            sudo initctl stop $SERVICE
+        fi
     fi
 fi

--- a/src/main/scripts/yadt-service-stop
+++ b/src/main/scripts/yadt-service-stop
@@ -7,5 +7,10 @@ export SERVICE=${1:?no SERVICE specified}
 if [[ $RELEASEVER == "7"* ]]; then
     sudo systemctl stop $SERVICE
 else
-    sudo service $SERVICE stop
+    eval $(yadt-service-init-type $YADT_SERVICE)
+    if [[ $YADT_INIT_TYPE == "sysv" ]]; then
+        sudo service $YADT_SERVICE stop
+    elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
+        sudo initctl stop $YADT_SERVICE
+    fi
 fi

--- a/src/main/scripts/yadt-service-stop
+++ b/src/main/scripts/yadt-service-stop
@@ -7,10 +7,10 @@ export SERVICE=${1:?no SERVICE specified}
 if [[ $RELEASEVER == "7"* ]]; then
     sudo systemctl stop $SERVICE
 else
-    eval $(yadt-service-init-type $YADT_SERVICE)
+    eval $(yadt-service-init-type $SERVICE)
     if [[ $YADT_INIT_TYPE == "sysv" ]]; then
-        sudo service $YADT_SERVICE stop
+        sudo service $SERVICE stop
     elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
-        sudo initctl stop $YADT_SERVICE
+        sudo initctl stop $SERVICE
     fi
 fi


### PR DESCRIPTION
The previous pull request could only handle Upstart daemon that only had a /etc/init/foo.conf. With this pull request, /etc/init/foo.override is also taken into consideration to determine if a service needs to be restarted.

Basically, yadtminion now supports multiple init scripts for a single service. This introduces a change to the service's JSON representation, but according to @arnehilmann this should not break anything.