### PR TITLE
Enable Systemd in yadt-minion

### DIFF
--- a/build.py
+++ b/build.py
@@ -44,7 +44,7 @@ name = 'yadt-minion'
 license = 'GNU GPL v3'
 summary = 'YADT - an Augmented Deployment Tool - The Minion Part'
 url = 'https://github.com/yadt/yadt-minion'
-version = '0.5'
+version = '0.6'
 
 default_task = ['analyze', 'publish']
 

--- a/build.py
+++ b/build.py
@@ -54,6 +54,7 @@ def set_properties(project):
     import os
 
     project.build_depends_on('mock')
+    project.build_depends_on('unittest2')
     project.depends_on('PyYAML')
     project.depends_on('netifaces')
     project.depends_on('simplejson')

--- a/build.py
+++ b/build.py
@@ -58,6 +58,7 @@ def set_properties(project):
     project.depends_on('netifaces')
     project.depends_on('simplejson')
     project.depends_on('pyrpm')
+    project.depends_on('sh')
 
     project.set_property('dir_dist_scripts', 'scripts')
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [bdist_rpm]
 packager = Arne Hilmann <arne.hilmann@gmail.com>
-requires = python >= 2.6 PyYAML yum python-netifaces python-simplejson
+requires = python >= 2.6 PyYAML yum python-netifaces python-simplejson python-sh
 release = 0%{?dist}

--- a/src/integrationtest/python/yadtminionutils_tests.py
+++ b/src/integrationtest/python/yadtminionutils_tests.py
@@ -1,0 +1,63 @@
+from yadtminionutils import get_files_by_template, get_systemd_overrides
+import os
+
+import unittest2 as unittest
+from tempfile import NamedTemporaryFile, mkdtemp
+
+
+class Test(unittest.TestCase):
+    def test_get_files_by_template_should_return_files_list(self):
+        service = "testservice"
+        tempfile1 = NamedTemporaryFile()
+        tempfile2 = NamedTemporaryFile()
+        expected_list = [tempfile1.name, tempfile2.name]
+
+        result_list = get_files_by_template(service, expected_list)
+        self.assertItemsEqual(expected_list, result_list)
+
+    def test_get_files_by_template_should_return_only_existing_files(self):
+        service = "testservice"
+        tempfile = NamedTemporaryFile()
+        expected_list = [tempfile.name]
+        result_list = get_files_by_template(service, [tempfile.name, "non_existing_file"])
+        self.assertListEqual(expected_list, result_list)
+
+    def test_get_files_by_template_should_return_empty_list(self):
+        service = "testservice"
+        expected_list = []
+        result_list = get_files_by_template(service, ["non_existing_file", "non_existing_file"])
+        self.assertItemsEqual(expected_list, result_list)
+        result_list = get_files_by_template(service, ["non_existing_file"])
+        self.assertItemsEqual(expected_list, result_list)
+        result_list = get_files_by_template(service, [])
+        self.assertItemsEqual(expected_list, result_list)
+
+    def test_get_systemd_overrides_should_return_list_files(self):
+        service = "testservice"
+        override_dir = mkdtemp()
+        override1 = NamedTemporaryFile(dir=override_dir)
+        override2 = NamedTemporaryFile(dir=override_dir)
+        expected_list = [override1.name, override2.name]
+        result_list = get_systemd_overrides(service, override_path_template=override_dir)
+        self.assertItemsEqual(expected_list, result_list)
+        override1.close()
+        override2.close()
+        os.rmdir(override_dir)
+
+    def test_get_systemd_overrides_should_return_empty_list_no_files(self):
+        service = "testservice"
+        override_dir = mkdtemp()
+        expected_list = []
+        result_list = get_systemd_overrides(service, override_path_template=override_dir)
+        self.assertItemsEqual(expected_list, result_list)
+        os.rmdir(override_dir)
+
+    def test_get_systemd_overrides_should_return_empty_list_no_directory(self):
+        service = "testservice"
+        override_dir = "nonexistent_dir"
+        expected_list = []
+        result_list = get_systemd_overrides(service, override_path_template=override_dir)
+        self.assertItemsEqual(expected_list, result_list)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/integrationtest/python/yadtminionutils_tests.py
+++ b/src/integrationtest/python/yadtminionutils_tests.py
@@ -79,6 +79,25 @@ class Test(unittest.TestCase):
         chkconfigmock.assert_called_once_with()
         self.assertFalse(is_sysv_service("noservice"))
 
+    @patch("yadtminionutils.sysv_scripts.Command")
+    def test_is_sysv_service_should_return_correct_value_with_xinetd(self, command):
+        chkconfigmock = Mock()
+        chkconfigmock.return_value = dedent("""
+            service1    	0:off   1:off   2:on    3:on    4:on    5:on    6:off
+            service2    	0:off   1:off   2:on    3:on    4:on    5:on    6:off
+            ser3           	0:off   1:off   2:off   3:on    4:on    5:on    6:off
+            service4    	0:off   1:off   2:on    3:on    4:on    5:on    6:off
+            longservice5	0:off   1:off   2:off   3:on    4:on    5:on    6:off
+            service6    	0:off   1:on    2:on    3:on    4:on    5:on    6:off
+
+            xinetd based services:
+                foobar-server:  on
+            """).strip().split("\n")
+        command.return_value = chkconfigmock
+        self.assertTrue(is_sysv_service("service1"))
+        chkconfigmock.assert_called_once_with()
+        self.assertFalse(is_sysv_service("noservice"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -309,7 +309,7 @@ class Status(object):
         override_exists = os.path.exists(upstart_override)
         yb = yum.YumBase()
         yb.doConfigSetup(init_plugins=False)
-        os_release = floar(yb.conf.yumvar['releasever'])
+        os_release = float(yb.conf.yumvar['releasever'])
 
 
         if Status.is_sysv_service(service_name):

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -266,27 +266,20 @@ class Status(object):
                 sys.stderr.write("Could not acquire yum lock : '%s'" % str(e))
                 sys.exit(1)
         self.yumdeps = YumDeps(self.yumbase)
-
         self.load_defaults_and_settings(only_config=False)
-
         self.setup_services()
         self.add_services_ignore()
         self.add_services_states()
         self.add_services_extra()
-
         self.handled_artefacts = [
             a for a in filter(self.artefacts_filter, self.yumdeps.requires.keys())]
-
         self.current_artefacts = self.yumdeps.requires.keys()
-
         self.next_artefacts = self.updates = {}
         self.yumdeps.load_all_updates()
         for a in filter(self.artefacts_filter, self.yumdeps.all_updates.keys()):
             self.updates[a] = self.yumdeps.all_updates[a]
         self.state = 'update_needed' if self.updates else 'uptodate'
-
         self.lockstate = self.get_lock_state()
-
         self.host = self.hostname = socket.gethostname().split('.', 1)[0]
         self.fqdn = socket.getfqdn()
         with open('/proc/uptime', 'r') as f:

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -199,7 +199,8 @@ class Status(object):
         result = list(updates.intersection(packages_inducing_reboot))
         return result
 
-    def is_sysv_service(self, service_name):
+    @staticmethod
+    def is_sysv_service(service_name):
         liste = [ line.split("\t" ,1)[0].strip() for line in sh.chkconfig() ]
         return service_name in liste
 

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -320,14 +320,14 @@ class Status(object):
         elif os_release >= 6 and os_release < 7:
             upstart_scripts = get_files_by_template(service_name,
                                                     upstart_scripts_temlpates)
-            if len(upstart_scripts):
+            if upstart_scripts:
                 init_type = "upstart"
                 init_scripts = upstart_scripts
             else:
                 init_type = "serverside"
         elif os_release >= 7:
             systemd_scripts = get_systemd_init_scripts(service_name)
-            if len(systemd_scripts):
+            if systemd_scripts:
                 init_type = "systemd"
                 init_scripts = systemd_scripts
             else:

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -321,7 +321,6 @@ class Status(object):
     @staticmethod
     def get_init_scripts_and_type(service_name):
         sysv_init_script = '/etc/init.d/%s' % service_name
-        sysv_exists = os.path.exists(sysv_init_script)
         upstart_init_script = '/etc/init/%s.conf' % service_name
         upstart_override = '/etc/init/%s.override' % service_name
         upstart_exists = os.path.exists(upstart_init_script)

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -206,6 +206,11 @@ class Status(object):
         return service_name in liste
 
     def __init__(self, only_config=False):
+        # Redirect stdout because some yum plugins will print to it and
+        # break the json
+        old_stdout = sys.stdout
+        sys.stdout = os.devnull
+
         self.service_defs = {}
         self.services = {}
 
@@ -284,6 +289,8 @@ class Status(object):
                                               'yumdeps',
                                               'service_defs',
                                               'artefacts_filter']]
+        sys.stdout = old_stdout
+        del old_stdout
 
     @staticmethod
     def get_systemd_init_scripts(service_name):

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -309,17 +309,17 @@ class Status(object):
         override_exists = os.path.exists(upstart_override)
         yb = yum.YumBase()
         yb.doConfigSetup(init_plugins=False)
-        os_release = yb.conf.yumvar['releasever']
+        os_release = floar(yb.conf.yumvar['releasever'])
 
 
         if Status.is_sysv_service(service_name):
             init_type = "sysv"
-        elif os_release == "6":
+        elif os_release >= 6 & os_release < 7:
             if upstart_exists:
                 init_type = "upstart"
             else:
                 init_type = "serverside"
-        elif os_release == "7":
+        elif os_release >= 7:
             if len(Status.get_systemd_init_scripts(service_name)):
                 init_type = "systemd"
             else:

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -226,6 +226,22 @@ class Status(object):
         yumbase.conf.cache = not(is_root)
         return yumbase
 
+    @staticmethod
+    def setup_interfaces():
+        """Return a dict of interfaces with a string of IP adresses"""
+        interfaces = {}
+        for interface in netifaces.interfaces():
+            if interface == 'lo':
+                continue
+            interfaces[interface] = []
+            try:
+                for link in netifaces.ifaddresses(interface)[netifaces.AF_INET]:
+                    interfaces[interface].append(link['addr'])
+            except Exception:
+                pass
+            interfaces[interface] = ' '.join(interfaces[interface])
+        return interfaces
+
     def __init__(self, only_config=False):
         # Redirect stdout because some yum plugins will print to it and
         # break the json
@@ -287,18 +303,7 @@ class Status(object):
         now = datetime.datetime.now()
         self.date = str(now)
         self.epoch = round(float(now.strftime('%s')))
-        self.interface = {}
-        for interface in netifaces.interfaces():
-            if interface == 'lo':
-                continue
-            self.interface[interface] = []
-            try:
-                for link in netifaces.ifaddresses(interface)[netifaces.AF_INET]:
-                    self.interface[interface].append(link['addr'])
-            except Exception:
-                pass
-            self.interface[interface] = ' '.join(self.interface[interface])
-
+        self.interface = Status.setup_interfaces()
         self.pwd = os.getcwd()
 
         self.structure_keys = [key for key in self.__dict__.keys()

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -6,7 +6,6 @@ import socket
 import datetime
 import stat
 import platform
-import sh
 
 import netifaces
 import yaml
@@ -15,6 +14,7 @@ import yadtminion.yaml_merger
 from yadtminion import locking
 import rpm
 from rpmUtils.miscutils import stringToVersion
+from sh import Command
 
 
 class YumDeps(object):
@@ -201,7 +201,8 @@ class Status(object):
 
     @staticmethod
     def is_sysv_service(service_name):
-        liste = [ line.split("\t" ,1)[0].strip() for line in sh.chkconfig() ]
+        chkconfig = Command("/sbin/chkconfig")
+        liste = [ line.split("\t" ,1)[0].strip() for line in chkconfig() ]
         return service_name in liste
 
     def __init__(self, only_config=False):

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -213,8 +213,8 @@ class Status(object):
     @staticmethod
     def is_sysv_service(service_name):
         chkconfig = Command("/sbin/chkconfig")
-        liste = [ line.split("\t" ,1)[0].strip() for line in chkconfig() ]
-        return service_name in liste
+        sysv_services = [line.split("\t", 1)[0].strip() for line in chkconfig()]
+        return service_name in sysv_services
 
     def __init__(self, only_config=False):
         # Redirect stdout because some yum plugins will print to it and
@@ -318,7 +318,6 @@ class Status(object):
         else:
             return tuple()
 
-
     @staticmethod
     def get_init_scripts_and_type(service_name):
         sysv_init_script = '/etc/init.d/%s' % service_name
@@ -330,7 +329,6 @@ class Status(object):
         yb = yum.YumBase()
         yb.doConfigSetup(init_plugins=False)
         os_release = float(yb.conf.yumvar['releasever'])
-
 
         if Status.is_sysv_service(service_name):
             init_type = "sysv"
@@ -344,7 +342,6 @@ class Status(object):
                 init_type = "systemd"
             else:
                 init_type = "serverside"
-
 
         if init_type == "sysv":
             init_scripts = (sysv_init_script,)

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -220,7 +220,7 @@ class Status(object):
         # Redirect stdout because some yum plugins will print to it and
         # break the json
         old_stdout = sys.stdout
-        sys.stdout = os.devnull
+        sys.stdout = open(os.devnull, "w")
 
         self.service_defs = {}
         self.services = {}

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -214,6 +214,8 @@ class Status(object):
             return
 
         self.yumbase = yum.YumBase()
+        # As the called script executes the yadt-status.py with sudo,
+        # this will nearly always be True
         is_root = os.geteuid() == 0
         self.yumbase.preconf.init_plugins = is_root
         self.yumbase.preconf.errorlevel = 0

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -318,10 +318,11 @@ class Status(object):
             else:
                 init_type = "serverside"
         elif os_release == "7":
-            if len(get_systemd_init_scripts(service_name)):
+            if len(Status.get_systemd_init_scripts(service_name)):
                 init_type = "systemd"
             else:
                 init_type = "serverside"
+
 
         if init_type == "sysv":
             init_scripts = (sysv_init_script,)
@@ -331,7 +332,7 @@ class Status(object):
             else:
                 init_scripts = (upstart_init_script,)
         elif init_type == "systemd":
-            init_scripts = get_systemd_init_scripts(service_name)
+            init_scripts = Status.get_systemd_init_scripts(service_name)
         else:
             init_scripts = tuple()
 

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -314,7 +314,7 @@ class Status(object):
 
         if Status.is_sysv_service(service_name):
             init_type = "sysv"
-        elif os_release >= 6 & os_release < 7:
+        elif os_release >= 6 and os_release < 7:
             if upstart_exists:
                 init_type = "upstart"
             else:

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -282,7 +282,7 @@ class Status(object):
                                               'artefacts_filter']]
 
     @staticmethod
-    def get_systemd_init_scripts(service_name)
+    def get_systemd_init_scripts(service_name):
         # are there other locations for services?
         systemd_init_script = '/usr/lib/systemd/system/%s.service' % service_name
         # simplified for a start

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -267,8 +267,8 @@ class Status(object):
 
         self.host = self.hostname = socket.gethostname().split('.', 1)[0]
         self.fqdn = socket.getfqdn()
-        f = open('/proc/uptime', 'r')
-        self.uptime = float(f.readline().split()[0])
+        with open('/proc/uptime', 'r') as f:
+            self.uptime = float(f.readline().split()[0])
         self.running_kernel = 'kernel/' + platform.uname()[2]
         self.latest_kernel = self.determine_latest_kernel()
         self.reboot_required_to_activate_latest_kernel = (self.running_kernel != self.latest_kernel

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -312,12 +312,12 @@ class Status(object):
 
         if Status.is_sysv_service(service_name):
             init_type = "sysv"
-        elif os_release == 6:
+        elif os_release == "6":
             if upstart_exists:
                 init_type = "upstart"
             else:
                 init_type = "serverside"
-        elif os_release == 7:
+        elif os_release == "7":
             if len(get_systemd_init_scripts(service_name)):
                 init_type = "systemd"
             else:

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -16,6 +16,17 @@ import rpm
 from rpmUtils.miscutils import stringToVersion
 from sh import Command
 
+# There is an longstanding bug in python that stdout not handled
+# correctly in a piping context.
+# http://bugs.python.org/issue11380
+import atexit
+@atexit.register
+def closefilehandler():
+    try:
+        sys.stdout.close()
+    except IOError:
+        pass
+
 
 class YumDeps(object):
     NAME_VERSION_SEPARATOR = '/'

--- a/src/main/python/yadtminion/__init__.py
+++ b/src/main/python/yadtminion/__init__.py
@@ -213,7 +213,7 @@ class Status(object):
     @staticmethod
     def is_sysv_service(service_name):
         chkconfig = Command("/sbin/chkconfig")
-        sysv_services = [line.split("\t", 1)[0].strip() for line in chkconfig()]
+        sysv_services = [line.split()[0] for line in chkconfig()]
         return service_name in sysv_services
 
     def __init__(self, only_config=False):

--- a/src/main/python/yadtminionutils/__init__.py
+++ b/src/main/python/yadtminionutils/__init__.py
@@ -1,0 +1,8 @@
+from .systemd_scripts import get_systemd_overrides, get_systemd_init_scripts
+from .sysv_scripts import is_sysv_service
+from .yadtminionutils import get_files_by_template
+
+__all__ = ["get_files_by_template",
+           "get_systemd_overrides",
+           "get_systemd_init_scripts",
+           "is_sysv_service"]

--- a/src/main/python/yadtminionutils/systemd_scripts.py
+++ b/src/main/python/yadtminionutils/systemd_scripts.py
@@ -1,0 +1,20 @@
+import os
+from .yadtminionutils import get_files_by_template
+
+
+def get_systemd_overrides(service_name, override_path_template='/etc/systemd/system/{0}.d'):
+    overrides = []
+    override_path = override_path_template.format(service_name)
+    if os.path.isdir(override_path):
+        for override_file in os.listdir(override_path):
+            full_path = os.path.join(override_path, override_file)
+            if os.path.isfile(full_path):
+                overrides.append(full_path)
+    return overrides
+
+
+def get_systemd_init_scripts(service_name):
+    init_scripts_templates = ['/usr/lib/systemd/system/{0}.service',
+                              '/etc/systemd/system/{0}.service']
+    return tuple(get_files_by_template(service_name, init_scripts_templates) +
+                 get_systemd_overrides(service_name))

--- a/src/main/python/yadtminionutils/sysv_scripts.py
+++ b/src/main/python/yadtminionutils/sysv_scripts.py
@@ -3,5 +3,11 @@ from sh import Command
 
 def is_sysv_service(service_name):
     chkconfig = Command("/sbin/chkconfig")
-    sysv_services = [line.split()[0] for line in chkconfig()]
+    sysv_services = []
+    for line in chkconfig():
+        line = line.strip()
+        if not line:
+            # Empty line is the start of the "xinetd based services" section.
+            break
+        sysv_services.append(line.split()[0])
     return service_name in sysv_services

--- a/src/main/python/yadtminionutils/sysv_scripts.py
+++ b/src/main/python/yadtminionutils/sysv_scripts.py
@@ -1,0 +1,7 @@
+from sh import Command
+
+
+def is_sysv_service(service_name):
+    chkconfig = Command("/sbin/chkconfig")
+    sysv_services = [line.split()[0] for line in chkconfig()]
+    return service_name in sysv_services

--- a/src/main/python/yadtminionutils/yadtminionutils.py
+++ b/src/main/python/yadtminionutils/yadtminionutils.py
@@ -1,0 +1,9 @@
+import os
+
+
+def get_files_by_template(common_name, list_of_templates):
+    existing_file_list = []
+    for file_to_test in [f.format(common_name) for f in list_of_templates]:
+        if os.path.exists(file_to_test):
+            existing_file_list.append(file_to_test)
+    return existing_file_list

--- a/src/main/python/yadtminionutils/yadtminionutils.py
+++ b/src/main/python/yadtminionutils/yadtminionutils.py
@@ -1,9 +1,11 @@
 import os
 
 
-def get_files_by_template(common_name, list_of_templates):
-    existing_file_list = []
-    for file_to_test in [f.format(common_name) for f in list_of_templates]:
+def get_files_by_template(common_name, filename_templates):
+    existing_files = []
+    files_to_test = [template.format(common_name)
+                     for template in filename_templates]
+    for file_to_test in files_to_test:
         if os.path.exists(file_to_test):
-            existing_file_list.append(file_to_test)
-    return existing_file_list
+            existing_files.append(file_to_test)
+    return existing_files

--- a/src/main/scripts/yadt-service-start
+++ b/src/main/scripts/yadt-service-start
@@ -11,22 +11,21 @@ is_already_starting() {
         pgrep -f "(service $SERVICE start|.*sh /etc/rc..d/S..$SERVICE start)" > /dev/null
     elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
         sudo initctl status $SERVICE | grep "start/" | grep -qv "start/running"
+    elif [[ $YADT_INIT_TYPE == "systemd" ]]; then
+        sudo systemctl status $SERVICE | grep -q "Active: activating"
     fi
 }
 
 if ! is_already_starting; then
     echo "starting $SERVICE"
-    if [[ $RELEASEVER == "7"* ]]
-    then
-        sudo systemctl start $SERVICE
-    else
-        if [[ $YADT_INIT_TYPE == "sysv" ]]; then
-            sudo service $SERVICE start
-        elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
-            if sudo initctl status $SERVICE | grep -q "stop/waiting"; then
-                sudo initctl start $SERVICE
-            fi
+    if [[ $YADT_INIT_TYPE == "sysv" ]]; then
+        sudo service $SERVICE start
+    elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
+        if sudo initctl status $SERVICE | grep -q "stop/waiting"; then
+            sudo initctl start $SERVICE
         fi
+    elif [[ $YADT_INIT_TYPE == "systemd" ]]; then
+        sudo systemctl start $SERVICE
     fi
     exit
 fi

--- a/src/main/scripts/yadt-service-status
+++ b/src/main/scripts/yadt-service-status
@@ -3,15 +3,13 @@ set -e -E -C -u -o pipefail
 
 export SERVICE=${1:?no YADT_SERVICE specified}
 
-if [[ $RELEASEVER == "7"* ]]; then
-    sudo systemctl status $SERVICE
-else
-    eval $(yadt-service-init-type $SERVICE)
-    if [[ $YADT_INIT_TYPE == "sysv" ]]; then
-        sudo service $SERVICE status
-    elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
-        if sudo initctl status $SERVICE | grep -q "stop/waiting"; then
-            exit 3
-        fi
+eval $(yadt-service-init-type $SERVICE)
+if [[ $YADT_INIT_TYPE == "sysv" ]]; then
+    sudo service $SERVICE status
+elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
+    if sudo initctl status $SERVICE | grep -q "stop/waiting"; then
+        exit 3
     fi
+elif [[ $YADT_INIT_TYPE == "systemd" ]]; then
+    sudo systemctl status $SERVICE >/dev/null
 fi

--- a/src/main/scripts/yadt-service-stop
+++ b/src/main/scripts/yadt-service-stop
@@ -4,15 +4,13 @@ set -e -E -C -u -o pipefail
 export SERVICE=${1:?no SERVICE specified}
 . yadt-service-checkaccess
 
-if [[ $RELEASEVER == "7"* ]]; then
-    sudo systemctl stop $SERVICE
-else
-    eval $(yadt-service-init-type $SERVICE)
-    if [[ $YADT_INIT_TYPE == "sysv" ]]; then
-        sudo service $SERVICE stop
-    elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
-        if sudo initctl status $SERVICE | grep -qv "stop/waiting"; then
-            sudo initctl stop $SERVICE
-        fi
+eval $(yadt-service-init-type $SERVICE)
+if [[ $YADT_INIT_TYPE == "sysv" ]]; then
+    sudo service $SERVICE stop
+elif [[ $YADT_INIT_TYPE == "upstart" ]]; then
+    if sudo initctl status $SERVICE | grep -qv "stop/waiting"; then
+        sudo initctl stop $SERVICE
     fi
+elif [[ $YADT_INIT_TYPE == "systemd" ]]; then
+    sudo systemctl stop $SERVICE >/dev/null
 fi


### PR DESCRIPTION
For CentOS7 we needed systemd support in yadt-minion. 
This change will allow yadt-minion to recognize systemd services and handle them appropriately in start, stop and status.

The rpm-artefakt discovery  does not yet support advanced systemd startscripts like templates, aliases,  sockets and user/runtime based files.