### PR TITLE
relinquish dependency on sh-module

### DIFF
--- a/build.py
+++ b/build.py
@@ -59,7 +59,6 @@ def set_properties(project):
     project.depends_on('netifaces')
     project.depends_on('simplejson')
     project.depends_on('pyrpm')
-    project.depends_on('sh')
 
     project.set_property('dir_dist_scripts', 'scripts')
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [bdist_rpm]
 packager = Arne Hilmann <arne.hilmann@gmail.com>
-requires = python >= 2.6 PyYAML yum python-netifaces python-simplejson python-sh
+requires = python >= 2.6 PyYAML yum python-netifaces python-simplejson
 release = 0%{?dist}

--- a/src/integrationtest/python/yadtminionutils_tests.py
+++ b/src/integrationtest/python/yadtminionutils_tests.py
@@ -65,26 +65,23 @@ class Test(unittest.TestCase):
         result_list = get_systemd_overrides(service, override_path_template=override_dir)
         self.assertItemsEqual(expected_list, result_list)
 
-    @patch("yadtminionutils.sysv_scripts.Command")
-    def test_is_sysv_service_should_return_correct_value(self, command):
-        chkconfigmock = Mock()
-        chkconfigmock.return_value = dedent("""
+    @patch("yadtminionutils.sysv_scripts.get_chkconfig_output")
+    def test_is_sysv_service_should_return_correct_value(self, get_chkconfig_output_mock):
+        get_chkconfig_output_mock.return_value = dedent("""
             service1    	0:off   1:off   2:on    3:on    4:on    5:on    6:off
             service2    	0:off   1:off   2:on    3:on    4:on    5:on    6:off
             ser3           	0:off   1:off   2:off   3:on    4:on    5:on    6:off
             service4    	0:off   1:off   2:on    3:on    4:on    5:on    6:off
             longservice5	0:off   1:off   2:off   3:on    4:on    5:on    6:off
             service6    	0:off   1:on    2:on    3:on    4:on    5:on    6:off
-            """).strip().split("\n")
-        command.return_value = chkconfigmock
+            """).strip()
         self.assertTrue(is_sysv_service("service1"))
-        chkconfigmock.assert_called_once_with()
+        get_chkconfig_output_mock.assert_called_once_with()
         self.assertFalse(is_sysv_service("noservice"))
 
-    @patch("yadtminionutils.sysv_scripts.Command")
-    def test_is_sysv_service_should_return_correct_value_with_xinetd(self, command):
-        chkconfigmock = Mock()
-        chkconfigmock.return_value = dedent("""
+    @patch("yadtminionutils.sysv_scripts.get_chkconfig_output")
+    def test_is_sysv_service_should_return_correct_value_with_xinetd(self, get_chkconfig_output_mock):
+        get_chkconfig_output_mock.return_value = dedent("""
             service1    	0:off   1:off   2:on    3:on    4:on    5:on    6:off
             service2    	0:off   1:off   2:on    3:on    4:on    5:on    6:off
             ser3           	0:off   1:off   2:off   3:on    4:on    5:on    6:off
@@ -94,10 +91,9 @@ class Test(unittest.TestCase):
 
             xinetd based services:
                 foobar-server:  on
-            """).strip().split("\n")
-        command.return_value = chkconfigmock
+            """).strip()
         self.assertTrue(is_sysv_service("service1"))
-        chkconfigmock.assert_called_once_with()
+        get_chkconfig_output_mock.assert_called_once_with()
         self.assertFalse(is_sysv_service("noservice"))
 
     def test_could_be_sysv_service(self):

--- a/src/main/python/yadtminionutils/sysv_scripts.py
+++ b/src/main/python/yadtminionutils/sysv_scripts.py
@@ -1,15 +1,16 @@
 import os
 import stat
-
-from sh import Command
+import subprocess
 
 SYSV_SCRIPT_LOCATION = "/etc/init.d"
 
+def get_chkconfig_output():
+    return subprocess.Popen(["/sbin/chkconfig"], stdout=subprocess.PIPE).communicate()[0]
 
 def is_sysv_service(service_name):
-    chkconfig = Command("/sbin/chkconfig")
+    chkconfig_output = get_chkconfig_output()
     sysv_services = []
-    for line in chkconfig():
+    for line in chkconfig_output.split("/n"):
         line = line.strip()
         if not line:
             # Empty line is the start of the "xinetd based services" section.


### PR DESCRIPTION
The sh-module may or may not be buggy---because we can't be sure and we only
use it once anyway, we replace it with a subprocess based implementation.